### PR TITLE
Allow Menu to Instantly Return without Selection

### DIFF
--- a/src/a8libmenu.c
+++ b/src/a8libmenu.c
@@ -70,6 +70,12 @@ byte Menu(byte bN, byte x, byte y, byte bO, byte bI, byte bS, byte bC, unsigned 
                 WPrint(bN, x, y+bL, (bL+1 == bR ? WON : WOFF), cL);
             }
         }
+	
+        // If display item is 0, exit
+        if (bS == GDISP) {
+            bF = TRUE;
+            continue;
+        }
 
         // Get key (no inverse key)
         bK = WaitKCX(WOFF);


### PR DESCRIPTION
If dev passes GDISP for bS argument, then loop breaks and control is returned instantly without selection process.

This enables similar behavior to Gadgets like GButton.

Ultimately, this allows the dev to compose a screen with multiple visible controls, without the Menu needing to be the initial focus.
